### PR TITLE
Potential fix for code scanning alert no. 9: Clear-text logging of sensitive information

### DIFF
--- a/brokle/observability/context.py
+++ b/brokle/observability/context.py
@@ -40,9 +40,7 @@ class ObservabilityContext:
             return {
                 "has_client": True,
                 "api_key": (
-                    client.config.api_key[:10] + "..."
-                    if client.config.api_key
-                    else None
+                    "<hidden>" if client.config.api_key else None
                 ),
                 "environment": client.config.environment,
                 "host": client.config.host,


### PR DESCRIPTION
Potential fix for [https://github.com/brokle-ai/brokle-python/security/code-scanning/9](https://github.com/brokle-ai/brokle-python/security/code-scanning/9)

To resolve this issue, we need to ensure that API keys (even partial) are never included in log messages. The fix should replace any value for `api_key` in the context info dictionary with a static placeholder such as `"<hidden>"` or simply omit the field from the dictionary returned by `get_info()`. This change needs to happen in `brokle/observability/context.py` inside the `ObservabilityContext.get_info()` method. By ensuring that `api_key` is never shown, downstream code (like `scripts/final_validation.py`) will never leak even partial keys in logs.

No changes are required in the logging or reporting functions themselves; the root is the info exposed via `get_info`/`get_context_info`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
